### PR TITLE
capture mouse offset on handle

### DIFF
--- a/app/scripts/directives/draggable.js
+++ b/app/scripts/directives/draggable.js
@@ -14,24 +14,28 @@ angular.module('iLayers')
       scope: {},
       replace: true,
       link: function postLink(scope, element, attrs) {
-        var handle = element.find('.drag-handle');
+        var handle = element.find('.drag-handle'),
+            offset = 0;
 
         scope.updatePosition = function(pos) {
             $('main').css('bottom', pos + 'px');
             $('footer').css('height', pos + 'px');
         };
 
-        handle.bind('mousedown', function() {
-          element.addClass('dragging');
+        handle.bind('mousedown', function(e) {
+          var $elem = $(e.currentTarget);
 
+          element.addClass('dragging');
+          offset = e.pageY - $elem.offset().top;
         });
+
         $('body').bind('mouseup', function() {
           element.removeClass('dragging');
         });
 
         $('body').bind('mousemove', function(e) {
           var height = $window.innerHeight,
-              bottom = height - e.pageY;
+              bottom = height - (e.pageY - offset);
 
           if (element.hasClass('dragging')) {
             scope.updatePosition(bottom);


### PR DESCRIPTION
eliminates the jump to the top of the handle when dragging.
