### PR TITLE
using calc for sticky width

### DIFF
--- a/app/scripts/directives/sticky.js
+++ b/app/scripts/directives/sticky.js
@@ -26,7 +26,6 @@ angular.module('iLayers')
           if (main.scrollTop() >= offset) {
             element.addClass('sticky');
           } else {
-            element.css('width', '100%');
             element.removeClass('sticky');
           }
         });

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -314,6 +314,7 @@ main {
       position: fixed;
       background: #d8d8d8;
       overflow: hidden;
+      width: calc(100% - 15px);
       top: 0;
       left: 0;
 
@@ -343,6 +344,7 @@ main {
     padding-left: 10px;
     white-space: nowrap;
     overflow: hidden;
+    box-sizing: content-box;
     border-bottom: 1px solid #b3b3b3;
 
     section {


### PR DESCRIPTION
![screen shot 2015-04-15 at 2 39 38 pm](https://cloud.githubusercontent.com/assets/923211/7167749/86ad06b0-e37d-11e4-9e05-313f2dccc48f.png)

using calc to keep the sticky header from overlapping the scrollbar.
