### PR TITLE
locking parameter added

### DIFF
--- a/app/scripts/controllers/dashboard.js
+++ b/app/scripts/controllers/dashboard.js
@@ -27,10 +27,11 @@ angular.module('iLayers')
         };
 
         self.searchImages = function(route) {
-
+          var searchTerms;
+          
           if (route.images !== undefined) {
             $scope.loading = true;
-            var searchTerms = self.buildTerms(route.images);
+            searchTerms = self.buildTerms(route.images);
 
             // Load Data
             registryService.inspect(searchTerms).then(function(response) {
@@ -47,7 +48,6 @@ angular.module('iLayers')
 
         // public
         $scope.graph = [];
-        $scope.lockedImage = undefined;
         
         $scope.filters =  {
           'image': ''
@@ -56,7 +56,8 @@ angular.module('iLayers')
         $scope.applyFilters = function(graphData, filter) {
           var filteredData = [],
               element = {},
-              key = '';
+              key = '',
+              locked = commandService.locked();
 
           for (var i=0; i < graphData.length; i ++) {
             element = graphData[i].repo;
@@ -65,6 +66,12 @@ angular.module('iLayers')
               filteredData.push(graphData[i]);
             }
           }
+          
+          $scope.$evalAsync(function() { 
+            commandService.release();
+            commandService.lock(locked) 
+          });
+          
           return filteredData;
         };
 

--- a/app/scripts/controllers/search.js
+++ b/app/scripts/controllers/search.js
@@ -68,6 +68,8 @@ angular.module('iLayers')
         $scope.addImages = function() {
           var sanitizedList = [];
 
+          $location.search('lock', null);
+          
           angular.forEach($scope.searchList, function(value) {
             if (value.name !== '' && value.found === true) {
               this.push(value);

--- a/app/scripts/directives/leaf.js
+++ b/app/scripts/directives/leaf.js
@@ -12,32 +12,46 @@ angular.module('iLayers')
       templateUrl:'views/leaf.html',
       restrict: 'E',
       replace: true,
+      controller: function($scope) {
+        var locked = commandService.locked(),
+            leaf = $scope.leaf;
+
+        if (locked !== undefined && leaf.name === locked.name && leaf.tag === locked.tag) {
+          $scope.lockParam = true;         
+        } 
+      },
       link: function(scope, element) { 
-        scope.showCommands = function(repo) {
+                
+        scope.showCommands = function(repo, force) {
           var data = scope.graph;
 
-          for (var i=0; i < data.length; i++) {
-            if (data[i].repo.name === repo.name && data[i].repo.tag === repo.tag) {
-              commandService.highlight(data[i].layers);
-              break;
+          if (repo) {
+            for (var i=0; i < data.length; i++) {
+              if (data[i].repo.name === repo.name && data[i].repo.tag === repo.tag) {
+                commandService.highlight(data[i].layers, force);
+                break;
+              }
             }
           }
         };
         
         scope.applyLock = function(repo) { 
-          var lock = commandService.lock();
+          var lock = commandService.locked();
           
           $('div.leaves section').removeClass('locked');
           
-          if (lock !== undefined && lock.identity === repo.identity) {
-            commandService.release();
+          commandService.release();
+          
+          if (lock !== undefined && lock.name === repo.name && lock.tag === repo.tag) {
+            scope.lockParam = false;
           } else {
-            element.addClass('locked');
-            commandService.release();
+            scope.lockParam = true;
             scope.showCommands(repo);
             commandService.lock(repo);
           }
-        }
+        };
+        
+        scope.showCommands(commandService.locked(), scope.lockParam);
       }
     };
   }]);

--- a/app/scripts/services/commandservice.js
+++ b/app/scripts/services/commandservice.js
@@ -6,7 +6,7 @@ angular.module('iLayers')
       var locked = undefined;
     
       return {
-          highlight: function (layers) {
+          highlight: function (layers, force) {
             var cmds = []
             for(var i=0; i < layers.length; i++) {
               var cmd = layers[i].container_config.Cmd,
@@ -14,8 +14,8 @@ angular.module('iLayers')
               
                 cmds.push(this.constructCommand(txt));
             }
-              
-            if (locked === undefined) {
+            
+            if (locked === undefined || force === true) {
               $rootScope.$broadcast('command-change', { 'commands': cmds });
             }
           },
@@ -45,18 +45,23 @@ angular.module('iLayers')
           clear: function() {
             $rootScope.$broadcast('command-change', { 'commands': [] });
           },
+          
+          locked: function() {
+            return locked;
+          },
         
           lock: function(image) {
             if (image !== undefined) {
               locked = image;
             }
             
-            $rootScope.$broadcast('lock-image', { 'image': image });
+            $rootScope.$broadcast('lock-image', { 'image': locked });
             return locked; 
           },
         
           release: function() {
             locked = undefined;
+            $rootScope.$broadcast('lock-image', { 'image': locked });
           }
       };
   }]);

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -540,9 +540,10 @@ footer {
     width: 100%;
     height: 100%;
     overflow: auto;
-
+    font-family: monospace;
     padding: 10px 20px;
-    font-size: 0.8em;
+    font-size: 0.95em;
+    line-height: 1.35em;
     color: #a0a0a0;
 
     li {

--- a/app/views/leaf.html
+++ b/app/views/leaf.html
@@ -1,4 +1,4 @@
-<section ng-mouseenter="showCommands(leaf)" ng-click="applyLock(leaf)">
+<section ng-mouseenter="showCommands(leaf)" ng-click="applyLock(leaf)" ng-class="{locked: lockParam}">
     <div class="remove" ng-click="removeImage(leaf)"></div>
     <div class="name">{{ leaf.name }}:{{ leaf.tag }}</div>
     <div class="size" ng-bind-html="leaf.size | size "></div>

--- a/test/spec/controllers/dashboard.js
+++ b/test/spec/controllers/dashboard.js
@@ -52,7 +52,6 @@ describe('DashboardCtrl', function() {
     beforeEach(inject(function($q) {
       deferredSuccess = $q.defer();
       spyOn(registryService, 'inspect').and.returnValue(deferredSuccess.promise);
-      //deferredSuccess.resolve({data: {'repo': {}, 'layers': []}});
     }));
 
     it('should do nothing when no images provided', function() {
@@ -108,6 +107,20 @@ describe('DashboardCtrl', function() {
 
       expect(result.length).toEqual(1);
       expect(result[0].repo.name).toEqual('foo');
+    });
+    
+    it('should call commandService.release()', function() {
+      spyOn(commandService,'release');
+      scope.applyFilters(data, 'foo');
+      scope.$digest();
+      expect(commandService.release).toHaveBeenCalled();
+    });
+    
+    it('should call commandService.lock()', function() {
+      spyOn(commandService,'lock');
+      scope.applyFilters(data, 'foo');
+      scope.$digest();
+      expect(commandService.lock).toHaveBeenCalledWith(undefined);
     });
   });
 });

--- a/test/spec/directives/grid.js
+++ b/test/spec/directives/grid.js
@@ -6,9 +6,9 @@ describe('Directive: grid', function () {
   // Load the templates
   beforeEach(module('views/grid.html'));
 
-var directive, scope, controller, layer, commandService, gridService;
+var directive, scope, route, controller, layer, commandService, gridService;
 
-  beforeEach(inject(function ($compile, $rootScope, _commandService_, _gridService_) {
+  beforeEach(inject(function ($compile, $rootScope, $routeParams, _commandService_, _gridService_) {
     var elem = angular.element("<section grid graph='graph'></section>");
     scope = $rootScope.$new();
     scope.graph = [];
@@ -19,6 +19,7 @@ var directive, scope, controller, layer, commandService, gridService;
     layer = { Size: 0, container_config: { Cmd: [] } };
     commandService = _commandService_;
     gridService = _gridService_;
+    route = $routeParams;
   }));
 
   describe('classifyLayer', function() {
@@ -38,6 +39,33 @@ var directive, scope, controller, layer, commandService, gridService;
       expect(controller.classifyLayer(layer, 1)).toEqual('box cat4');
       layer.container_config.Cmd = ['FROM '];
       expect(controller.classifyLayer(layer, 1)).toEqual('box cat5');
+    });
+  });
+  
+  describe('$scope.checkLockParam', function() {
+    beforeEach(function() {
+      spyOn(commandService, 'lock');
+    });
+    
+    describe('when route has lock', function() {
+      it('should call commandService.lock', function() {
+        route.lock = 'test:foo';
+        scope.checkLockParam();
+        expect(commandService.lock).toHaveBeenCalledWith({ name: 'test', tag: 'foo' });
+      });
+      
+      it('should add latest tag if not provided', function() {
+        route.lock = 'test';
+        scope.checkLockParam();
+        expect(commandService.lock).toHaveBeenCalledWith({ name: 'test', tag: 'latest' });
+      });
+    });
+    
+    describe('when route has no lock', function() {
+      it('should not call commandService.lock', function() {
+        scope.checkLockParam();
+        expect(commandService.lock).not.toHaveBeenCalled();
+      });
     });
   });
   

--- a/test/spec/directives/leaf.js
+++ b/test/spec/directives/leaf.js
@@ -29,7 +29,7 @@ describe('Directive: leaf', function () {
     it('should send all layers to commandService.highlight', function() {
       repo = { 'name': 'foo', 'tag': 'do'};
       scope.showCommands(repo);
-      expect(commandService.highlight).toHaveBeenCalledWith(['one','two']);
+      expect(commandService.highlight).toHaveBeenCalledWith(['one','two'], undefined);
     });
 
     it('should not call commandService if no image matches', function() {
@@ -50,9 +50,9 @@ describe('Directive: leaf', function () {
         spyOn(commandService, 'lock').and.returnValue(undefined);
       });
       
-      it('adds locked class to element', function() {
+      it('sets lockParam', function() {
         scope.applyLock(repo);
-        expect(elem.hasClass('locked')).toBeTruthy();
+        expect(scope.lockParam).toBeTruthy();
       });
       
       it('calls release on commandService', function() {


### PR DESCRIPTION
adding lock=name:tag will lock that image and its layers when initially loaded. The lock will remain during filtering and can be unlocked manually. The flag remains on the url so browser refresh will keep the lock. When search is used the lock parameter is removed.
