### PR TITLE
About menu/journal height

### DIFF
--- a/app/scripts/directives/about.js
+++ b/app/scripts/directives/about.js
@@ -45,7 +45,7 @@
 
             aboutMenu.css('display', 'block');
             aboutMenu.animate({
-              'top': (position.top + height) + 'px',
+              'top': (position.top + (height - $('main').scrollTop())) + 'px',
               'opacity': 1
             }, speed, function() {
               scope.menuVisible = true;

--- a/app/scripts/directives/draggable.js
+++ b/app/scripts/directives/draggable.js
@@ -24,7 +24,7 @@
 
         scope.updatePosition = function(pos) {
             $('main').css('bottom', pos + 'px');
-            $('footer').css('height', pos + 'px');
+            $('footer#journal').css('height', pos + 'px');
         };
 
         handle.bind('mousedown', function(e) {

--- a/app/views/dashboard.html
+++ b/app/views/dashboard.html
@@ -46,7 +46,7 @@
     <section class="graph" grid>
     </section>
 </main>
-<footer>
+<footer id="journal">
     <draggable></draggable>
     <section class="journal" scroll-glue ng-controller="JournalCtrl">
         <ul>


### PR DESCRIPTION
The draggable journal was setting the height on the footer element in the about menu. Also adding some offset in the event someone has scrolled before viewing the about menu. This is a temporary fix -- the about menu is going to be available on click instead of hover.