### PR TITLE
Making menu visible on click instead of hover

### DIFF
--- a/app/scripts/directives/about.js
+++ b/app/scripts/directives/about.js
@@ -20,67 +20,32 @@
         $templateRequest('views/about-menu.html');
       },
       link: function postLink(scope, element) {
-        var position = element.position(),
-            speed = 400;
-
-        scope.bindEvents = function(menu) {
-          menu.bind('mouseover', function() {
-              scope.menuActive = true;
-          });
-          menu.bind('mouseleave', function() {
-            scope.menuActive = false;
-            scope.hideMenu(menu);
-          });
-        };
-
-        scope.unbindEvents = function(menu) {
-          menu.unbind('mouseover');
-          menu.unbind('mouseleave');
-        };
-
-        scope.showMenu = function(aboutMenu) {
-          if (!scope.menuVisible) {
-            scope.bindEvents(aboutMenu);
-
-            aboutMenu.css('display', 'block');
-            aboutMenu.animate({
-              'top': 59 + 'px',
-              'opacity': 1
-            }, speed, function() {
-              scope.menuVisible = true;
-            });
-          }
-        };
-
-        scope.hideMenu = function(aboutMenu) {
-          if (scope.menuVisible && !scope.menuActive) {
-            scope.unbindEvents(aboutMenu);
-
-            aboutMenu.animate({
-              'top': (position.top + 90) + 'px',
-              'opacity': 0
-            }, speed, function() { 
-              aboutMenu.css('display','none'); 
-              scope.menuVisible = false;
-            });
-          }
-        };
+        var main = element.closest('main'),
+          headerHeight = $('header').height();
 
         scope.menuVisible = false;
-        scope.menuActive = false;
 
-        element.bind('mouseover', function() {
+        element.bind('click', function() {
+          console.log('click');
           var aboutMenu = $('div.about');
-          scope.showMenu(aboutMenu);
+          aboutMenu.slideToggle();
+          scope.menuVisible = !scope.menuVisible;
         });
 
-        element.bind('mouseleave', function() {
-          var aboutMenu = $('div.about');
-          $timeout(function() {
-            scope.hideMenu(aboutMenu);
-          }, 120);
-        });
-      } 
+        scope.toggleMenu = function(aboutMenu) {
+          aboutMenu.slideToggle();
+          scope.menuVisible = !scope.menuVisible;
+        };
+
+        main.bind('scroll', function () {
+          if (scope.menuVisible) {
+            if (headerHeight < $('main').scrollTop()) {
+              var aboutMenu = $('div.about');
+              scope.toggleMenu(aboutMenu);
+            }
+          }
+        })
+      }
     };
   }
 })();

--- a/app/styles/header.scss
+++ b/app/styles/header.scss
@@ -6,7 +6,7 @@ div.about {
   display: none;
   z-index: 300;
   position: absolute;
-  top: 100px;
+  top: 59px;
   left: 190px;
   width: 722px;
   background-color: #fff;

--- a/app/views/dashboard.html
+++ b/app/views/dashboard.html
@@ -15,9 +15,10 @@
             <a about href="">About</a>
         </nav>
     </header>
-    <section class="metrics"> 
+    <div ng-include="'views/about-menu.html'"></div>
+    <section class="metrics">
       <badge></badge>
-      <metrics></metrics> 
+      <metrics></metrics>
     </section>
     <section sticky offset='134' class="search" ng-controller="SearchCtrl as search">
       <div class="manage-images">
@@ -47,4 +48,3 @@
         </ul>
     </section>
 </footer>
-<div ng-include="'views/about-menu.html'"></div>

--- a/test/spec/directives/about.js
+++ b/test/spec/directives/about.js
@@ -4,7 +4,7 @@ describe('Directive: about', function () {
 
   // load the directive's module
   beforeEach(module('iLayers'));
-    // Load the templates
+  // Load the templates
   beforeEach(module('views/about-menu.html'));
 
   var directive, scope, controller, elem, menu;
@@ -12,76 +12,27 @@ describe('Directive: about', function () {
   beforeEach(inject(function ($compile, $rootScope) {
     var rootScope = $rootScope.$new();
     elem = angular.element("<div about></div><ul class='about'></ul>");
-    
+
 
     directive = $compile(elem)(rootScope);
     rootScope.$digest();
     controller = elem.controller('about');
     scope = elem.isolateScope();
-    menu = $('div.about');
+    menu = $('ul.about');
   }));
-  
-  describe('scope.showMenu', function() {    
-    describe('when menu is not visible', function() {
-      beforeEach(function() {
-        scope.menuVisible = false; 
-      });
-      
-      it('should bind events to menu', function() {
-        spyOn(scope, 'bindEvents');
-        scope.showMenu(menu);
-        
-        expect(scope.bindEvents).toHaveBeenCalled();
-      });
-      
-      it('should call animate', function() {
-        spyOn(menu, 'animate');
-        scope.showMenu(menu);
-        
-        expect(menu.animate).toHaveBeenCalled();
-      });
-    });
-  });
-  
-  describe('scope.hideMenu', function() {
+
+  describe('scope.toggleMenu', function() {
     describe('when menu is visible and not active', function() {
       beforeEach(function() {
         scope.menuVisible = true;
-        scope.menuActive = false;
       });
-      
-      it('should unbind events', function() {
-        spyOn(scope, 'unbindEvents');
-        scope.hideMenu(menu);
-      
-        expect(scope.unbindEvents).toHaveBeenCalled();
-      });
-      
-      it('should call animate', function() {
-        spyOn(menu, 'animate');
-        scope.hideMenu(menu);
-        
-        expect(menu.animate).toHaveBeenCalled();
+
+      it('should call slideToggle', function() {
+        spyOn(menu, 'slideToggle');
+        scope.toggleMenu(menu);
+
+        expect(menu.slideToggle).toHaveBeenCalled();
       });
     });
-  });
-  
-  describe('when mouseover', function() {
-    it('should call showMenu', function() {
-      spyOn(scope, 'showMenu');
-      elem.trigger('mouseover');
-      
-      expect(scope.showMenu).toHaveBeenCalled();
-    });
-  });
-  
-  describe('when mouseleave', function() {
-    it('should call hideMenu', inject(function($timeout) {
-      spyOn(scope, 'hideMenu');
-      elem.trigger('mouseleave');
-      
-      $timeout.flush();
-      expect(scope.hideMenu).toHaveBeenCalled();
-    }));
   });
 });


### PR DESCRIPTION
This moves the about menu into the header (to avoid scroll issues) and also makes it visible only on click, not hover. If the user scrolls while the menu is visible, it will slide up after the header is scrolled out of pane.