### PR TITLE
Update repo.hub_link

### DIFF
--- a/app/scripts/services/gridservice.js
+++ b/app/scripts/services/gridservice.js
@@ -220,8 +220,8 @@
             if (id !== 'empty') {
               angular.copy(grid.matrix.inventory[id].image.repo, repo);
               repo.identity = repo.name + '::' + repo.tag + Math.floor(Math.random() * 10000);
-              var link = repo.name.lastIndexOf('/') < 0 ? '_/' + repo.name : 'u/' + repo.name;
-              repo.hub_link = 'https://registry.hub.docker.com/' + link;
+              var link = repo.name.lastIndexOf('/') < 0 ? '_/' + repo.name : 'r/' + repo.name;
+              repo.hub_link = 'https://hub.docker.com/' + link;
               leaves.push(repo);
               break;
             }

--- a/test/spec/services/gridservice.js
+++ b/test/spec/services/gridservice.js
@@ -109,7 +109,7 @@ describe('Service: gridService', function () {
         }
       },
       res = gridService.findLeaves(data);
-      expect(res[0].hub_link).toEqual('https://registry.hub.docker.com/_/official');
+      expect(res[0].hub_link).toEqual('https://hub.docker.com/_/official');
     });
     it('creates a valid docker hub link for images from individuals and organizations', function () {
       var data = {
@@ -119,7 +119,7 @@ describe('Service: gridService', function () {
         }
       },
       res = gridService.findLeaves(data);
-      expect(res[0].hub_link).toEqual('https://registry.hub.docker.com/u/foo/test');
+      expect(res[0].hub_link).toEqual('https://hub.docker.com/r/foo/test');
     });
   });
 });


### PR DESCRIPTION
Link to Docker Hub (https://registry.hub.docker.com/u/ + repo.name) does not work well.

It is recommended to update to https://hub.docker.com/r/ + repo.name